### PR TITLE
Fix typo 'abilties'

### DIFF
--- a/mediawiki/resources/lib/oojs-ui/oojs-ui.js
+++ b/mediawiki/resources/lib/oojs-ui/oojs-ui.js
@@ -10985,7 +10985,7 @@ OO.ui.ItemWidget.prototype.setElementGroup = function ( group ) {
  * @constructor
  * @param {OO.ui.OutlineSelectWidget} outline Outline to control
  * @param {Object} [config] Configuration options
- * @cfg {Object} [abilities] List of abilties
+ * @cfg {Object} [abilities] List of abilities
  * @cfg {boolean} [abilities.move=true] Allow moving movable items
  * @cfg {boolean} [abilities.remove=true] Allow removing removable items
  */
@@ -11068,7 +11068,7 @@ OO.mixinClass( OO.ui.OutlineControlsWidget, OO.ui.IconElement );
 /**
  * Set abilities.
  *
- * @param {Object} abilities List of abilties
+ * @param {Object} abilities List of abilities
  * @param {boolean} [abilities.move] Allow moving movable items
  * @param {boolean} [abilities.remove] Allow removing removable items
  */

--- a/mediawiki/vendor/oojs/oojs-ui/src/widgets/OutlineControlsWidget.js
+++ b/mediawiki/vendor/oojs/oojs-ui/src/widgets/OutlineControlsWidget.js
@@ -11,7 +11,7 @@
  * @constructor
  * @param {OO.ui.OutlineSelectWidget} outline Outline to control
  * @param {Object} [config] Configuration options
- * @cfg {Object} [abilities] List of abilties
+ * @cfg {Object} [abilities] List of abilities
  * @cfg {boolean} [abilities.move=true] Allow moving movable items
  * @cfg {boolean} [abilities.remove=true] Allow removing removable items
  */
@@ -94,7 +94,7 @@ OO.mixinClass( OO.ui.OutlineControlsWidget, OO.ui.IconElement );
 /**
  * Set abilities.
  *
- * @param {Object} abilities List of abilties
+ * @param {Object} abilities List of abilities
  * @param {boolean} [abilities.move] Allow moving movable items
  * @param {boolean} [abilities.remove] Allow removing removable items
  */


### PR DESCRIPTION

Hi! I'm a bot that checks GitHub for spelling mistakes, and I found one in your repository. When it
should be 'abilities', you typed 'abilties'. I created this pull request to fix it!

If you think there is anything wrong with this pull request or just have a question, be kind to mail me 
at thetypomaster@hotmail.com (professional email, huh?). I’ll try to address the problem as soon as
I’m aware of it.

Looking for the source code of this bot? Well, you have to be patient! The bot is under development
and I will publish the source code as soon as I’m finished with it.

With kind regards,
TheTypoMaster
            